### PR TITLE
Adjust `Gradle` to build app

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,8 +74,4 @@ ext {
     kotlinCoroutinesVersion = '1.3.9'
     roomVersion = "2.3.0"
     wordPressUtilsVersion = "develop-eebc5d8e91a1d90190919f900f924b39c861a528"
-
-    fluxcAnnotationsProjectDependency = project.hasProperty("fluxcAnnotationsVersion") ? "org.wordpress.fluxc:fluxc-annotations:${project.getProperty("fluxcAnnotationsVersion")}" : project(":fluxc-annotations")
-    fluxcProcessorProjectDependency = project.hasProperty("fluxcProcessorVersion") ? "org.wordpress.fluxc:fluxc-processor:${project.getProperty("fluxcProcessorVersion")}" : project(":fluxc-processor")
-    fluxcProjectDependency = project.hasProperty("fluxcVersion") ? "org.wordpress:fluxc:${project.getProperty("fluxcVersion")}" : project(":fluxc")
 }

--- a/instaflux/build.gradle
+++ b/instaflux/build.gradle
@@ -33,7 +33,10 @@ android {
 
 android.buildTypes.all { buildType ->
     // Add properties named "wp.xxx" to our BuildConfig
-    project.properties.any { property ->
+    Properties apiProperties = loadPropertiesOrUseExampleProperties("api.properties",
+            "example app can't access WordPress.com servers")
+
+    apiProperties.any { property ->
         if (property.key.toLowerCase().startsWith("wp.")) {
             buildType.buildConfigField "String", property.key.replace("wp.", "").replace(".", "_").toUpperCase(),
                     "\"${property.value}\""
@@ -41,8 +44,29 @@ android.buildTypes.all { buildType ->
     }
 }
 
+def loadPropertiesOrUseExampleProperties(fileName, warningDetail) {
+    Properties properties = new Properties()
+    File propertiesFile = file(propertiesFilePath(fileName))
+    if (propertiesFile.exists()) {
+        properties.load(new InputStreamReader(new FileInputStream(propertiesFile), "utf-8"))
+    } else {
+        def examplePropertiesFilePath = examplePropertiesFilePath(fileName)
+        logger.quiet("WARNING: you're using the '$examplePropertiesFilePath' file - $warningDetail")
+        properties.load(new InputStreamReader(new FileInputStream(file(examplePropertiesFilePath)), "utf-8"))
+    }
+    return properties
+}
+
+static def propertiesFilePath(fileName) {
+    return "../example/properties/$fileName"
+}
+
+static def examplePropertiesFilePath(fileName) {
+    return "../example/properties-example/$fileName"
+}
+
 dependencies {
-    implementation project(':fluxc');
+    implementation("org.wordpress:fluxc:develop-e490ac0557848d32e28781e7f8fca4923e587a98")
 
     // WordPress libs
     implementation("org.wordpress:utils:$wordPressUtilsVersion") {

--- a/settings.gradle
+++ b/settings.gradle
@@ -37,13 +37,7 @@ pluginManagement {
     }
 }
 
-include ':fluxc',
-        ':fluxc-processor',
-        ':fluxc-annotations',
-        ':plugins:woocommerce',
-        ':example',
-        ':instaflux',
-        ':tests:api'
+include ':instaflux'
 
 // Build cache is only enabled for CI, at least for now
 if (System.getenv().containsKey("CI")) {


### PR DESCRIPTION
This PR adjusts build configuration to allow build `InstaFlux` with both:
- example secrets
- secrets applied after `applyConfiguration` task

It also removes references to modules from FluxC.